### PR TITLE
Add bind config to xinetd::service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class xinetd {
     #       per_source  => "11",
     #   } # xinetd::service
     #
-    define service ($cps = undef, $flags = undef, $per_source = undef, $port, $server, $server_args = undef, $disable = "no", $socket_type = "stream", $protocol = "tcp", $user = "root", $group = "root", $instances = "UNLIMITED", $wait = undef) {
+    define service ($cps = undef, $flags = undef, $per_source = undef, $port, $server, $server_args = undef, $disable = "no", $socket_type = "stream", $protocol = "tcp", $user = "root", $group = "root", $instances = "UNLIMITED", $wait = undef, $bind = '0.0.0.0') {
         if $wait {
             $mywait = $wait
         } else {

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -10,6 +10,7 @@ service <%= name %>
         user            = <%= user %>
         group           = <%= group %>
         server          = <%= server %>
+        bind            = <%= bind %>
 <% if server_args != :undef %>        server_args     = <%= server_args %><% end %>
 <% if per_source != :undef %>        per_source      = <%= per_source %><% end %>
 <% if cps != :undef %>        cps             = <%= cps %><% end %>


### PR DESCRIPTION
This commit adds bind to the list of parameters
that can be configured for an xinted hosted service.

This allows you to specify the interace that the service
will bind to.
