### PR TITLE
Adapt for use on multiple operating systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class xinetd {
   package { $xinetd::params::xinetd_package: }
 
   file { $xinetd::params::xinetd_conffile:
-    source => 'puppet:///modules/xinetd/xinetd.conf',
+    content => template('xinetd/xinetd.conf.erb'),
   }
 
   service { $xinetd::params::xinetd_service:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,17 +12,35 @@
 class xinetd {
   include xinetd::params
 
-  package { $xinetd::params::xinetd_package: }
+  File {
+    owner   => 'root',
+    group   => '0',
+    notify  => Service[$xinetd::params::xinetd_service],
+    require => Package[$xinetd::params::xinetd_package],
+  }
+
+  file { $xinetd::params::xinetd_confdir:
+    ensure  => directory,
+    mode    => '0755',
+  }
 
   file { $xinetd::params::xinetd_conffile:
+    ensure  => file,
+    mode    => '0644',
     content => template('xinetd/xinetd.conf.erb'),
   }
 
-  service { $xinetd::params::xinetd_service:
-    ensure  => running,
-    enable  => true,
-    restart => '/etc/init.d/xinetd reload',
-    require => [ Package[$xinetd::params::xinetd_package],
-                 File[$xinetd::params::xinetd_conffile] ],
+  package { $xinetd::params::xinetd_package:
+    ensure => installed,
+    before => Service[$xinetd::params::xinetd_service],
   }
+
+  service { $xinetd::params::xinetd_service:
+    ensure     => running,
+    enable     => true,
+    hasrestart => true,
+    hasstatus  => true,
+    require    => File[$xinetd::params::xinetd_conffile],
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,18 +10,19 @@
 #  }
 #
 class xinetd {
+  include xinetd::params
 
-  package { 'xinetd': }
+  package { $xinetd::params::xinetd_package: }
 
-  file { '/etc/xinetd.conf':
+  file { $xinetd::params::xinetd_conffile:
     source => 'puppet:///modules/xinetd/xinetd.conf',
   }
 
-  service { 'xinetd':
+  service { $xinetd::params::xinetd_service:
     ensure  => running,
     enable  => true,
     restart => '/etc/init.d/xinetd reload',
-    require => [ Package['xinetd'],
-                 File['/etc/xinetd.conf'] ],
+    require => [ Package[$xinetd::params::xinetd_package],
+                 File[$xinetd::params::xinetd_conffile] ],
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,34 @@
+class xinetd::params {
+
+  case $osfamily {
+    'Debian':  {
+      $xinetd_confdir  = '/etc/xinetd.d'
+      $xinetd_conffile = '/etc/xinetd.conf'
+      $xinetd_package  = 'xinetd'
+      $xinetd_service  = 'xinetd'
+    }
+    'FreeBSD': {
+      $xinetd_confdir  = '/usr/local/etc/xinetd.d'
+      $xinetd_conffile = '/usr/local/etc/xinetd.conf'
+      $xinetd_package  = 'security/xinetd'
+      $xinetd_service  = 'xinetd'
+    }
+    'Suse':  {
+      $xinetd_confdir  = '/etc/xinetd.d'
+      $xinetd_conffile = '/etc/xinetd.conf'
+      $xinetd_package  = 'xinetd'
+      $xinetd_service  = 'xinetd'
+    }
+    'Solaris': {
+      fail('xinetd: module does not support Solaris')
+    }
+    default:   {
+      $xinetd_confdir  = '/etc/xinetd.d'
+      $xinetd_conffile = '/etc/xinetd.conf'
+      $xinetd_package  = 'xinetd'
+      $xinetd_service  = 'xinetd'
+    }
+  }
+
+}
+

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,20 +4,27 @@
 # all parameters match up with xinetd.conf(5) man page
 #
 # Parameters:
-#   $port        - required - determines the service port
-#   $server      - required - determines the program to execute for this service
-#   $cps         - optional
-#   $flags       - optional
-#   $per_source  - optional
-#   $server_args - optional
-#   $disable     - optional - defaults to 'no'
-#   $socket_type - optional - defaults to 'stream'
-#   $protocol    - optional - defaults to 'tcp'
-#   $user        - optional - defaults to 'root'
-#   $group       - optional - defaults to 'root'
-#   $instances   - optional - defaults to 'UNLIMITED'
-#   $wait        - optional - based on $protocol will default to 'yes' for udp and 'no' for tcp
-#   $bind        - optional - defaults to '0.0.0.0'
+#   $cps            - optional
+#   $flags          - optional
+#   $per_source     - optional
+#   $port           - required - determines the service port
+#   $server         - required - determines the program to execute for this service
+#   $server_args    - optional
+#   $disable        - optional - defaults to "no"
+#   $socket_type    - optional - defaults to "stream"
+#   $protocol       - optional - defaults to "tcp"
+#   $user           - optional - defaults to "root"
+#   $group          - optional - defaults to "root"
+#   $groups         - optional - defaults to "yes"
+#   $instances      - optional - defaults to "UNLIMITED"
+#   $log_on_failure - optional
+#   $only_from      - optional
+#   $wait           - optional - based on $protocol will default to "yes" for udp and "no" for tcp
+#   $xtype          - optional - determines the "type" of service, see xinetd.conf(5)
+#   $no_access      - optional
+#   $access_times   - optional
+#   $log_type       - optional
+#   $bind           - optional
 #
 # Actions:
 #   setups up a xinetd service by creating a file in /etc/xinetd.d/
@@ -28,45 +35,62 @@
 #
 # Sample Usage:
 #   # setup tftp service
-#   xinetd::service { 'tftp':
-#     port        => '69',
-#     server      => '/usr/sbin/in.tftpd',
-#     server_args => '-s $base',
-#     socket_type => 'dgram',
-#     protocol    => 'udp',
-#     cps         => '100 2',
-#     flags       => 'IPv4',
-#     per_source  => '11',
+#   xinetd::service {"tftp":
+#       port        => "69",
+#       server      => "/usr/sbin/in.tftpd",
+#       server_args => "-s $base",
+#       socket_type => "dgram",
+#       protocol    => "udp",
+#       cps         => "100 2",
+#       flags       => "IPv4",
+#       per_source  => "11",
 #   } # xinetd::service
 #
 define xinetd::service (
   $port,
   $server,
-  $cps         = undef,
-  $flags       = undef,
-  $per_source  = undef,
-  $server_args = undef,
-  $disable     = 'no',
-  $socket_type = 'stream',
-  $protocol    = 'tcp',
-  $user        = 'root',
-  $group       = 'root',
-  $instances   = 'UNLIMITED',
-  $wait        = undef,
-  $bind        = '0.0.0.0'
+  $ensure         = present,
+  $service_name   = $title,
+  $cps            = undef,
+  $disable        = "no",
+  $flags          = undef,
+  $group          = "root",
+  $groups         = "yes",
+  $instances      = "UNLIMITED",
+  $log_on_failure = undef,
+  $per_source     = undef,
+  $protocol       = "tcp",
+  $server_args    = undef,
+  $socket_type    = "stream",
+  $user           = "root",
+  $only_from      = undef,
+  $wait           = undef,
+  $xtype          = undef,
+  $no_access      = undef,
+  $access_times   = undef,
+  $log_type       = undef,
+  $bind           = undef
 ) {
+  include xinetd
+  include xinetd::params
 
   if $wait {
-    $mywait = $wait
+    $wait_real = $wait
   } else {
-    $mywait = $protocol ? {
-      tcp => 'no',
-      udp => 'yes'
+    case $protocol {
+      'tcp':   { $wait_real = 'no'  }
+      'udp':   { $wait_real = 'yes' }
+      default: { fail('wait not set, unable to determine sane default') }
     }
   }
 
-  file { "/etc/xinetd.d/${name}":
+  file { "${xinetd::params::xinetd_confdir}/${title}":
+    ensure  => $ensure,
+    owner   => 'root',
+    mode    => '0644',
     content => template('xinetd/service.erb'),
-    notify  => Service['xinetd'],
+    notify  => Service[$xinetd::params::xinetd_service],
+    require => File[$xinetd::params::xinetd_confdir],
   }
+
 }

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -1,18 +1,48 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
 
-service <%= name %>
+service <%= service_name %>
 {
         disable         = <%= disable %>
         socket_type     = <%= socket_type %>
         protocol        = <%= protocol %>
-        wait            = <%= mywait %>
+        wait            = <%= wait_real %>
+        port            = <%= port %>
         user            = <%= user %>
         group           = <%= group %>
+        groups          = <%= groups %>
         server          = <%= server %>
+<% if server_args != :undef -%>
+        server_args     = <%= server_args %>
+<% end -%>
+<% if only_from != :undef -%>
+        only_from       = <%= only_from %>
+<% end -%>
+<% if per_source != :undef -%>
+        per_source      = <%= per_source %>
+<% end -%>
+<% if log_on_failure != :undef -%>
+        log_on_failure += <%= log_on_failure %>
+<% end -%>
+<% if cps != :undef -%>
+        cps             = <%= cps %>
+<% end -%>
+<% if flags != :undef -%>
+        flags           = <%= flags %>
+<% end -%>
+<% if xtype != :undef -%>
+        type            = <%= xtype %>
+<% end -%>
+<% if no_access != :undef -%>
+        no_access       = <%= no_access %>
+<% end -%>
+<% if access_times != :undef -%>
+        access_times    = <%= access_times %>
+<% end -%>
+<% if log_type != :undef -%>
+        log_type        = <%= log_type %>
+<% end -%>
+<% if bind != :undef -%>
         bind            = <%= bind %>
-<% if server_args != :undef %>        server_args     = <%= server_args %><% end %>
-<% if per_source != :undef %>        per_source      = <%= per_source %><% end %>
-<% if cps != :undef %>        cps             = <%= cps %><% end %>
-<% if flags != :undef %>        flags           = <%= flags %><% end %>
+<% end -%>
 }

--- a/templates/xinetd.conf.erb
+++ b/templates/xinetd.conf.erb
@@ -48,5 +48,4 @@ defaults
 #       banner_success  =
 }
 
-includedir /etc/xinetd.d
-
+includedir <%= scope.lookupvar('xinetd::params::xinetd_confdir') %>


### PR DESCRIPTION
The attached commits make some pretty serious changes to the xinetd module in order to give it support for multiple operating systems and greater flexibility. Commit messages given below in roughly markdown format:
- Add xinetd::params class
  
  The params class uses facts to set tailored filenames and paths for the node. This is desireable in order to support multiple operating systems.
- Convert files/xinetd.conf to a template
  
  Not all operating systems store their default xinetd configuration file in /etc/xinetd.conf. Converting from a flat file to a template in order to support those operating systems.
- Manage xinetd.d, rework init.pp
  
  Make sure xinetd.d exists (not all OS packages automatically create such a file). Also rework init.pp order.
- Expand xinetd::service options
  
  Add a bunch of extra xinetd::service parameters. Refactor a bit. Options that default to undef are not given a corresponding line in the xinetd service file, leaving their value to the xinetd default.
  
  Modified options:
  - bind = undef
  
  New options:
  - access_times   = undef
  - ensure         = present
  - groups         = 'yes'
  - log_on_failure = undef
  - log_type       = undef
  - no_access      = undef
  - only_from      = undef
  - service_name   = $title
  - xtype          = undef
